### PR TITLE
Fix workspace only in root issue + GitHub comment with colored diff 

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -67,7 +67,7 @@ function run() {
                     core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                     core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
-                    const filePath = path_1
+                    const filePath = file
                     const cleanedPath = filePath.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
                     core.log(`Cleaned path: ${cleanedPath}`); // Output: environments/terrakube-testing
                     

--- a/dist/main.js
+++ b/dist/main.js
@@ -164,6 +164,7 @@ function checkTerrakubeLogs(terrakubeClient, githubToken, organizationId, jobId,
             //const commentBody = `Logs from step: ${jobSteps[index].attributes.name} \`\`\`\n${convert.toHtml(body)}\n\`\`\` `
             if (show_output) {
                 body = body.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+                body = body.replace(/^(\s*)\+/gm, '+$1');
                 const commentBody = `\n ## Logs: ${jobSteps[index].attributes.name} status ${jobSteps[index].attributes.status} \n \`\`\`diff\n${body}\n\`\`\` `;
                 finalComment = finalComment.concat(commentBody);
             }

--- a/dist/main.js
+++ b/dist/main.js
@@ -62,7 +62,9 @@ function run() {
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
+                    core.info(`File ${file}`);
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
+                    core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""

--- a/dist/main.js
+++ b/dist/main.js
@@ -67,12 +67,9 @@ function run() {
                     core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                     core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
-                    const filePath = file
-                    const cleanedPath = filePath.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
-                    core.info(`Cleaned path: ${cleanedPath}`); // Output: environments/terrakube-testing
+                    const workspaceFolder = file.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
+                    core.info(`workspaceFolder: ${workspaceFolder}`); // Output: environments/terrakube-testing
                     
-                    core.info(`Path_1: ${path_1}`)
-                    const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
                         ? terrakubeData.workspace : workspaceFolder;

--- a/dist/main.js
+++ b/dist/main.js
@@ -68,7 +68,7 @@ function run() {
                     core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
                     const workspaceFolder = file.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
-                    core.info(`workspaceFolder: ${workspaceFolder}`); // Output: environments/terrakube-testing
+                    core.info(`workspaceFolder: ${workspaceFolder}`);
                     
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,6 +59,7 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
+            core.info(`Terrakube Folders List: ${githubActionInput.terrakubeFolder.split(" ")}`);
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
@@ -67,14 +68,13 @@ function run() {
                     core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                     core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
-                    const workspaceFolder = file.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
-                    core.info(`workspaceFolder: ${workspaceFolder}`);
-                    
-                    core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
+                    const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
+                    const isFolderChanged = githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1;
+                    core.info(`Folder ${workspaceFolder} change: ${isFolderChanged}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
-                        ? terrakubeData.workspace : workspaceFolder.split('/').pop();
+                        ? terrakubeData.workspace : workspaceFolder;
                     //Folder with terrakube.json file change
-                    if (githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1) {
+                    if (isFolderChanged) {
                         core.startGroup(`Execute Workspace ${workspaceName}`);
                         console.debug(`Processing: ${file}`);
                         core.debug(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -70,7 +70,7 @@ function run() {
 
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     const isFolderChanged = githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1;
-                    core.info(`Folder ${workspaceFolder} change: ${isFolderChanged}`);
+                    core.info(`Folder ${workspaceFolder} was_changed: ${isFolderChanged}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
                         ? terrakubeData.workspace : workspaceFolder;
                     //Folder with terrakube.json file change
@@ -164,7 +164,7 @@ function checkTerrakubeLogs(terrakubeClient, githubToken, organizationId, jobId,
             //const commentBody = `Logs from step: ${jobSteps[index].attributes.name} \`\`\`\n${convert.toHtml(body)}\n\`\`\` `
             if (show_output) {
                 body = body.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
-                const commentBody = `\n ## Logs: ${jobSteps[index].attributes.name} status ${jobSteps[index].attributes.status} \n \`\`\`\n${body}\n\`\`\` `;
+                const commentBody = `\n ## Logs: ${jobSteps[index].attributes.name} status ${jobSteps[index].attributes.status} \n \`\`\`diff\n${body}\n\`\`\` `;
                 finalComment = finalComment.concat(commentBody);
             }
         }

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,16 +59,17 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
+            const terrakubeFolders = githubActionInput.terrakubeFolder.split(" ");
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
-                    core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
+                    core.info(`Folder ${workspaceFolder} change: ${terrakubeFolders.indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
                         ? terrakubeData.workspace : workspaceFolder;
                     //Folder with terrakube.json file change
-                    if (githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1) {
+                    if (terrakubeFolders.indexOf(workspaceFolder) > -1) {
                         core.startGroup(`Execute Workspace ${workspaceName}`);
                         console.debug(`Processing: ${file}`);
                         core.debug(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -69,9 +69,9 @@ function run() {
 
                     const filePath = file
                     const cleanedPath = filePath.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
-                    core.log(`Cleaned path: ${cleanedPath}`); // Output: environments/terrakube-testing
+                    core.info(`Cleaned path: ${cleanedPath}`); // Output: environments/terrakube-testing
                     
-                    core.log(`Path_1: ${path_1}`)
+                    core.info(`Path_1: ${path_1}`)
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""

--- a/dist/main.js
+++ b/dist/main.js
@@ -63,10 +63,7 @@ function run() {
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
-                    core.info(`File ${file}`);
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
-                    core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
-                    core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     const isFolderChanged = githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1;

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,7 +59,6 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
-            core.info(`Terrakube Folders List: ${githubActionInput.terrakubeFolder.split(" ")}`);
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
@@ -68,6 +67,11 @@ function run() {
                     core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                     core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
 
+                    const filePath = path_1
+                    const cleanedPath = filePath.replace(/^\/home\/runner\/_work\/[^\/]+\/[^\/]+\//, '').replace(/\/terrakube\.json$/, '');
+                    core.log(`Cleaned path: ${cleanedPath}`); // Output: environments/terrakube-testing
+                    
+                    core.log(`Path_1: ${path_1}`)
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""

--- a/dist/main.js
+++ b/dist/main.js
@@ -72,7 +72,7 @@ function run() {
                     
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
-                        ? terrakubeData.workspace : workspaceFolder;
+                        ? terrakubeData.workspace : workspaceFolder.split('/').pop();
                     //Folder with terrakube.json file change
                     if (githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1) {
                         core.startGroup(`Execute Workspace ${workspaceName}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,21 +59,18 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
-            const terrakubeFolders = githubActionInput.terrakubeFolder.split(" ");
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
-                    core.info(`Andrew Workspace Folder: ${workspaceFolder}`);
-                    core.info(`Terrakube Folders: ${terrakubeFolders}`);
-                    const isFolderChanged = terrakubeFolders.some(folder => workspaceFolder.startsWith(folder));
-                    core.info(`Folder ${workspaceFolder} change: ${isFolderChanged}`);
+                    core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
                         ? terrakubeData.workspace : workspaceFolder;
                     //Folder with terrakube.json file change
-                    if (isFolderChanged) {
+                    if (githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder) > -1) {
                         core.startGroup(`Execute Workspace ${workspaceName}`);
+                        console.debug(`Processing: ${file}`);
                         core.debug(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                         core.info(`Organization: ${githubActionInput.terrakubeOrganization}`);
                         core.info(`Workspace: ${workspaceName}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -65,13 +65,15 @@ function run() {
                     const file = _c.value;
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
-                    core.info(`Folder ${workspaceFolder} change: ${terrakubeFolders.indexOf(workspaceFolder)}`);
+                    core.info(`Andrew Workspace Folder: ${workspaceFolder}`);
+                    core.info(`Terrakube Folders: ${terrakubeFolders}`);
+                    const isFolderChanged = terrakubeFolders.some(folder => workspaceFolder.startsWith(folder));
+                    core.info(`Folder ${workspaceFolder} change: ${isFolderChanged}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""
                         ? terrakubeData.workspace : workspaceFolder;
                     //Folder with terrakube.json file change
-                    if (terrakubeFolders.indexOf(workspaceFolder) > -1) {
+                    if (isFolderChanged) {
                         core.startGroup(`Execute Workspace ${workspaceName}`);
-                        console.debug(`Processing: ${file}`);
                         core.debug(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
                         core.info(`Organization: ${githubActionInput.terrakubeOrganization}`);
                         core.info(`Workspace: ${workspaceName}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -147,7 +147,7 @@ function checkTerrakubeLogs(terrakubeClient, githubToken, organizationId, jobId,
         const httpClient = terrakubeClient.httpClient;
         const jobSteps = jobResponseJson.included;
         core.info(`${Object.keys(jobSteps).length}`);
-        let finalComment = `## Workspace: ${workspaceFolder} Status: ${jobResponseJson.data.attributes.status.toUpperCase()} \n`;
+        let finalComment = `## Workspace: \`${workspaceFolder}\` Status: \`${jobResponseJson.data.attributes.status.toUpperCase()}\` \n`;
         for (let index = 0; index < Object.keys(jobSteps).length; index++) {
             core.startGroup(`Running ${jobSteps[index].attributes.name}`);
             const response = yield httpClient.get(`${jobSteps[index].attributes.output}`, {

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,12 +59,15 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
+            core.info(`Terrakube Folders List: ${githubActionInput.terrakubeFolder.split(" ")}`);
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;
                     core.info(`File ${file}`);
                     const terrakubeData = JSON.parse(yield (0, promises_1.readFile)(`${file}`, "utf8"));
                     core.info(`Loaded JSON: ${JSON.stringify(terrakubeData)}`);
+                    core.info(`TerrakubeFolder: ${githubActionInput.terrakubeFolder}`);
+
                     const workspaceFolder = path_1.default.basename(path_1.default.dirname(file));
                     core.info(`Folder ${workspaceFolder} change: ${githubActionInput.terrakubeFolder.split(" ").indexOf(workspaceFolder)}`);
                     const workspaceName = terrakubeData.workspace && terrakubeData.workspace.trim() !== ""

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,7 +59,6 @@ function run() {
             const patterns = ['**/terrakube.json'];
             const globber = yield glob.create(patterns.join('\n'));
             core.info(`Changed Directory: ${githubActionInput.terrakubeFolder}`);
-            core.info(`Terrakube Folders List: ${githubActionInput.terrakubeFolder.split(" ")}`);
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
                     const file = _c.value;


### PR DESCRIPTION
Previously if the workspace was inside `environments/*` sub dir, it would catch a change, this PR fix it.
Colorful diffs are added as a comments