### PR TITLE
feat: respect branch name override from action

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Add the following snippet to the script section of your github actions file:
 ### Pull Request example
 
 To run a terraform plan using Terrakube templates use the following example:
+
 > File: .github/workflows/pull_request.yml
+
 ```yaml
 name: Terrakube Plan
 
@@ -24,7 +26,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: "Running Terrakube Plan"
+    name: 'Running Terrakube Plan'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,21 +34,23 @@ jobs:
 
       - uses: AzBuilder/terrakube-action-github@main
         with:
-          TERRAKUBE_TOKEN:  ${{ secrets.TERRAKUBE_PAT }} 
-          TERRAKUBE_TEMPLATE: "Terraform-Plan"
-          TERRAKUBE_ENDPOINT: ${{ secrets.TERRAKUBE_ENDPOINT }}  
+          TERRAKUBE_TOKEN: ${{ secrets.TERRAKUBE_PAT }}
+          TERRAKUBE_TEMPLATE: 'Terraform-Plan'
+          TERRAKUBE_ENDPOINT: ${{ secrets.TERRAKUBE_ENDPOINT }}
           TERRAKUBE_BRANCH: ${{ github.head_ref }}
-          TERRAKUBE_ORGANIZATION: "terrakube_organization_name"
+          TERRAKUBE_ORGANIZATION: 'terrakube_organization_name'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOW_OUTPUT: true
-
 ```
+
 > A new workspace will be created for each folder with the file "terrakube.json". For each PR only new folders or folders that has been updated will be evaluated inside Terrakube.
 
 ### Push Main branch
 
 To run a terraform apply using Terrakube templates use the following example:
+
 > File: .github/workflows/push_main.yml
+
 ```yaml
 name: Terrakube Apply
 
@@ -58,7 +62,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: "Running Terrakube Apply"
+    name: 'Running Terrakube Apply'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -66,14 +70,13 @@ jobs:
 
       - uses: AzBuilder/terrakube-action-github@main
         with:
-          TERRAKUBE_TOKEN:  ${{ secrets.TERRAKUBE_PAT }} 
-          TERRAKUBE_TEMPLATE: "Terraform-Plan/Apply"
-          TERRAKUBE_ENDPOINT: ${{ secrets.TERRAKUBE_GITPOD }}  
-          TERRAKUBE_BRANCH: "main"
-          TERRAKUBE_ORGANIZATION: "terrakube_organization_name"
+          TERRAKUBE_TOKEN: ${{ secrets.TERRAKUBE_PAT }}
+          TERRAKUBE_TEMPLATE: 'Terraform-Plan/Apply'
+          TERRAKUBE_ENDPOINT: ${{ secrets.TERRAKUBE_GITPOD }}
+          TERRAKUBE_BRANCH: 'main'
+          TERRAKUBE_ORGANIZATION: 'terrakube_organization_name'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOW_OUTPUT: false
-
 ```
 
 ## Terrakube Variables
@@ -81,21 +84,20 @@ jobs:
 To define terrakube variables to connect to cloud providers it is recommended to use Global Variables inside the organization using the UI.
 Terraform variables could be define inside a terraform.tfvars inside each folder or you can define inside the Terrakube UI after the workspace creation.
 
-
 ## GitHub Action Inputs
 
-| Variable                    | Usage                                              |
-| --------------------------- | -------------------------------------------------- |
-| TERRAKUBE_TOKEN (*)         | Terrakube Personal Access Token                    |
-| TERRAKUBE_TEMPLATE (*)      | Terrakube template name                            |
-| TERRAKUBE_ENDPOINT (*)      | Terrakbue api endpoint                             |
-| TERRAKUBE_ORGANIZATION (*)  | Terrakbue organization                             |
-| TERRAKUBE_BRANCH (*)        | Github Branch when running a job                   |
-| TERRAKUBE_SSH_KEY_NAME      | ssh key name define in the terrakube organization to connect to private repositories  |
-| GITHUB_TOKEN (*)            | Github Token                                       |
-| SHOW_OUTPUT (*)             | Show terrakube logs inside PR comments             |
+| Variable                    | Usage                                                                                | Default |
+| --------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| TERRAKUBE_TOKEN (\*)        | Terrakube Personal Access Token                                                      |         |
+| TERRAKUBE_TEMPLATE (\*)     | Terrakube template name                                                              |         |
+| TERRAKUBE_ENDPOINT (\*)     | Terrakbue api endpoint                                                               |         |
+| TERRAKUBE_ORGANIZATION (\*) | Terrakbue organization                                                               |         |
+| TERRAKUBE_BRANCH (\*)       | Github Branch when running a job                                                     | "main"  |
+| TERRAKUBE_SSH_KEY_NAME      | ssh key name define in the terrakube organization to connect to private repositories |         |
+| GITHUB_TOKEN (\*)           | Github Token                                                                         |         |
+| SHOW_OUTPUT (\*)            | Show terrakube logs inside PR comments                                               |         |
 
-_(*) = required variable._
+_(\*) = required variable._
 
 ## Terraform Workspace Configuration
 
@@ -119,6 +121,7 @@ yarn build
 ```
 
 ## Support
+
 If you’d like help with this github action, or you have an issue or feature request, let us know.
 
 If you’re reporting an issue, please include:
@@ -126,4 +129,3 @@ If you’re reporting an issue, please include:
 - the version of the github action
 - relevant logs and error messages
 - steps to reproduce
-

--- a/action.yml
+++ b/action.yml
@@ -1,48 +1,49 @@
-name: 'TerrakubeAction'
-description: 'Github integration with Terrakube Platform'
+name: "TerrakubeAction"
+description: "Github integration with Terrakube Platform"
 branding:
-  icon: 'package'
-  color: 'purple'
+  icon: "package"
+  color: "purple"
 inputs:
   TERRAKUBE_TOKEN:
-    description: 'Terrakube Personal Access Token'
+    description: "Terrakube Personal Access Token"
     required: true
   TERRAKUBE_ENDPOINT:
-    description: 'Terrakube Endpoint'
+    description: "Terrakube Endpoint"
     required: true
   TERRAKUBE_TEMPLATE:
-    description: 'Terrakube Template'
+    description: "Terrakube Template"
     required: true
   TERRAKUBE_ORGANIZATION:
-    description: 'Terrakube Organization'
+    description: "Terrakube Organization"
     required: true
   TERRAKUBE_BRANCH:
-    description: 'Repository branch to be executed'
+    description: "Repository branch to be executed"
+    default: "main"
     required: true
   TERRAKUBE_SSH_KEY_NAME:
-    description: 'Repository branch to be executed'
+    description: "Repository branch to be executed"
     required: false
   SHOW_OUTPUT:
-    description: 'Show Terrakube job output inside github commets'
+    description: "Show Terrakube job output inside github commets"
     required: true
   GITHUB_TOKEN:
-    description: 'Github Token'
+    description: "Github Token"
     required: true
   IGNORE_SSL_ERROR:
-    description: 'Ignore SSL errors (e.g. self-signed certificate)'
+    description: "Ignore SSL errors (e.g. self-signed certificate)"
     required: false
     default: false
 outputs:
   JOB_ID:
-    description: 'Terrakube Job Execution Id'
+    description: "Terrakube Job Execution Id"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Get changed folders
       id: changed-files
       uses: tj-actions/changed-files@v45
       with:
-        dir_names: 'true'
+        dir_names: "true"
 
     - name: List all folder changes
       shell: bash
@@ -62,7 +63,7 @@ runs:
         yarn install
         yarn build
       working-directory: ${{ github.action_path }}
-    
+
     - run: |
         node ${{ github.action_path }}/dist/main.js
       id: terrakube-integration

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ async function run(): Promise<void> {
             core.info(`Using template id ${templateId}`)
 
             core.info(`Creating new job: `)
-            const jobId = await terrakubeClient.createJobId(organizationId, workspaceId, templateId)
+            const jobId = await terrakubeClient.createJobId(organizationId, workspaceId, templateId, githubActionInput.branch)
             core.debug(`JobId: ${jobId}`)
 
 

--- a/src/terrakube.ts
+++ b/src/terrakube.ts
@@ -342,7 +342,7 @@ export class TerrakubeClient {
 
     }
 
-    async createJobId(organizationId: string, workspaceId: string, templateId: string): Promise<any> {
+    async createJobId(organizationId: string, workspaceId: string, templateId: string, branchName: string): Promise<any> {
         if (this.authenticationToken === 'empty') {
             this.authenticationToken = this.gitHubActionInput.token
         }
@@ -351,7 +351,8 @@ export class TerrakubeClient {
             "data": {
                 "type": "job",
                 "attributes": {
-                    "templateReference": templateId
+                    "templateReference": templateId,
+                    "overrideBranch": branchName
                 },
                 "relationships": {
                     "workspace": {


### PR DESCRIPTION
Adds the branch name to createJobId and forces default branch name as main against Github action when not provided.

fixes #31