### PR TITLE
ci: pin actions versions to commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   steps:
     - name: Get changed folders
       id: changed-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
       with:
         dir_names: "true"
 

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
         done
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: 16
 


### PR DESCRIPTION
## Description
This PR pins GitHub actions to commit SHAs. With all the GitHub actions/supply chain attacks recently, it is an especially critical time to pin actions versions.

Our GitHub orgs now also enforce commit SHA pinning for actions, so this is a necessary update for us to continue using this action.

| Action | Version | Commit SHA |
|---|---|---
| tj-actions/changed-files | [v47.0.5](https://github.com/tj-actions/changed-files/releases/tag/v47.0.5) | 22103cc46bda19c2b464ffe86db46df6922fd323 |
| actions/setup-node | [v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0) | 53b83947a5a98c8d113130e565377fae1a50d02f |

It might also be a good idea to enable immutable releases for this repository.
